### PR TITLE
Array support

### DIFF
--- a/manifests/encapsulate.pp
+++ b/manifests/encapsulate.pp
@@ -1,7 +1,7 @@
 # ex: syntax=puppet si ts=4 sw=4 et
 
 define racoon::encapsulate (
-    $local_ip    = '%{::ipaddress}',
+    $local_ip    = $::ipaddress,
     $remote_ip   = '0.0.0.0/0',
     $local_port  = 'any',
     $remote_port = 'any',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,9 +2,9 @@
 
 class racoon (
     $package_name,
-    $version,
+    $version='present',
     $ipsec_tools_package_name,
-    $ipsec_tools_version,
+    $ipsec_tools_version='present',
     $service_name,
     $pre_shared_keys = {},
     $encapsulate     = {},
@@ -22,7 +22,7 @@ class racoon (
 
     package { 'racoon':
         name   => $package_name,
-        ensure => $package_version,
+        ensure => $version,
     }
 
     package { 'ipsec-tools':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class racoon (
     $ipsec_tools_package_name,
     $ipsec_tools_version='present',
     $service_name,
+    $local_gateway   = $::ipaddress,
     $pre_shared_keys = {},
     $encapsulate     = {},
     $iptunnels       = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,13 @@
 # ex: si ts=4 sw=4 et
 
 class racoon (
-    $package_name,
-    $version='present',
-    $ipsec_tools_package_name,
-    $ipsec_tools_version='present',
-    $service_name,
+    $package_name    = 'racoon',
+    $version         = 'present',
+    $ipsec_tools_package_name = 'ipsec-tools',
+    $ipsec_tools_version = 'present',
+    $service_name    = 'racoon',
+    $restart         = 'restart',
+    $setkey_restart  = 'restart',
     $local_gateway   = $::ipaddress,
     $policy_level    = 'require',
     $pre_shared_keys = {},
@@ -61,15 +63,48 @@ class racoon (
         name       => $service_name,
         ensure     => running,
         pattern    => '/usr/sbin/racoon',
-        hasstatus  => false,
-        hasrestart => true,
         subscribe  => File['/etc/racoon/racoon.conf', '/etc/racoon/psk.txt'],
     }
-
+    case $restart {
+        'restart': {
+            Service['racoon'] {
+                hasrestart => true
+            }
+        }
+        'reload': {
+            Service['racoon'] {
+                restart    => "/usr/sbin/service ${service_name} ${restart}",
+            }
+        }
+        false: {
+            Service['racoon'] {
+                restart    => '/bin/true',
+            }
+        }
+        default: {
+            fail("Invalid value for racoon::restart: ${restart}")
+        }
+    }
     exec { 'setkey restart':
-        command     => '/usr/sbin/service setkey restart',
         user        => 'root',
         refreshonly => true,
         subscribe   => [ File['/etc/ipsec-tools.conf'], Service['racoon'] ],
     }
+    case $setkey_restart {
+        'restart', 'start', 'reload': {
+            # reload is not supported in Ubuntu yet
+            Exec['setkey restart'] {
+                command => "/usr/sbin/service setkey ${setkey_restart}"
+            }
+        }
+        false: {
+            Exec['setkey restart'] {
+                command => '/bin/true'
+            }
+        }
+        default: {
+            fail("Invalid value for racoon::setkey_restart: ${setkey_restart}")
+        }
+    }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class racoon (
     $ipsec_tools_version='present',
     $service_name,
     $local_gateway   = $::ipaddress,
+    $policy_level    = 'require',
     $pre_shared_keys = {},
     $encapsulate     = {},
     $iptunnels       = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,6 @@ class racoon (
     $encapsulate     = {},
     $iptunnels       = {},
     $remotes         = {},
-    $associations    = {},
     $log_level       = 'notify',
 ) {
     File {

--- a/manifests/iptunnel.pp
+++ b/manifests/iptunnel.pp
@@ -6,6 +6,7 @@ define racoon::iptunnel (
     $remote_net,
     $remote_gateway,
     $proto          = 'any',
+    $policy_level   = $::racoon::policy_level,
 ) {
     file { "/etc/ipsec-tools.d/${name}-iptunnel.conf":
         ensure  => present,

--- a/manifests/iptunnel.pp
+++ b/manifests/iptunnel.pp
@@ -2,7 +2,7 @@
 
 define racoon::iptunnel (
     $local_net,
-    $local_gateway  = $::ipaddress,
+    $local_gateway  = $::racoon::local_gateway,
     $remote_net,
     $remote_gateway,
     $proto          = 'any',

--- a/templates/ipsec-tools/iptunnel.erb
+++ b/templates/ipsec-tools/iptunnel.erb
@@ -3,9 +3,9 @@
     Array(@remote_net).each do |rnet|
 -%>
 spdadd <%= lnet %> <%= rnet %> <%= @proto %> -P out ipsec
-	esp/tunnel/<%= @local_gateway %>-<%= @remote_gateway %>/require;
+	esp/tunnel/<%= @local_gateway %>-<%= @remote_gateway %>/<%= @policy_level %>;
 spdadd <%= rnet %> <%= lnet %> <%= @proto %> -P in ipsec
-	esp/tunnel/<%= @remote_gateway %>-<%= @local_gateway %>/require;
+	esp/tunnel/<%= @remote_gateway %>-<%= @local_gateway %>/<%= @policy_level %>;
 
 <%  end
   end

--- a/templates/ipsec-tools/iptunnel.erb
+++ b/templates/ipsec-tools/iptunnel.erb
@@ -1,4 +1,12 @@
-spdadd <%= @local_net %> <%= @remote_net %> <%= @proto %> -P out ipsec
+<%
+  Array(@local_net).each do |lnet|
+    Array(@remote_net).each do |rnet|
+-%>
+spdadd <%= lnet %> <%= rnet %> <%= @proto %> -P out ipsec
 	esp/tunnel/<%= @local_gateway %>-<%= @remote_gateway %>/require;
-spdadd <%= @remote_net %> <%= @local_net %> <%= @proto %> -P in ipsec
+spdadd <%= rnet %> <%= lnet %> <%= @proto %> -P in ipsec
 	esp/tunnel/<%= @remote_gateway %>-<%= @local_gateway %>/require;
+
+<%  end
+  end
+-%>

--- a/templates/racoon.conf.erb
+++ b/templates/racoon.conf.erb
@@ -2,10 +2,12 @@
 remote_defaults = {
     'passive' => false,
     'initial_contact' => true,
-    'proposal_check' => 'strict'
+    'proposal_check' => 'strict',
+    'dpd_delay' => 20
 }
 sainfo_defaults = {
-    'type' => 'anonymous'
+    'type' => 'anonymous',
+    'dh_group' => 'modp1024'
 }
 -%>
 #
@@ -47,13 +49,15 @@ remote <%= params['address'] %> {
 	nat_traversal <%= params['nat_traversal'] %>;
 	proposal_check <%= params['proposal_check'] %>;
 
-	dpd_delay 20;
-
+	dpd_delay <%= params['dpd_delay'] %>;
+<%- unless params['lifetime'].nil? -%>
+	lifetime <%= params['lifetime'] %>
+<% end -%>
 	proposal {
 		encryption_algorithm <%= params['proposal']['encryption_algorithm'] %>;
 		hash_algorithm <%= params['proposal']['hash_algorithm'] %>;
 		authentication_method pre_shared_key;
-		dh_group modp1024;
+		dh_group <%= params['proposal']['dh_group'] %>;
 	}
 }
 <%- end -%>
@@ -63,17 +67,27 @@ remote <%= params['address'] %> {
       rproto = params['remote_proto'] || 'any'
       case params['type']
           when 'anonymous'
-              spec = 'anonymous'
+              sainfos = ['anonymous']
           when 'identifiers'
-              spec = "address #{params['local_net']} #{lproto} address #{params['remote_net']} #{rproto}"
+              sainfos = []
+              Array(params['local_net']).each do |lnet|
+                  Array(params['remote_net']).each do |rnet|
+                      sainfos += ["address #{lnet} #{lproto} address #{rnet} #{rproto}"]
+                  end
+              end
       end
       spec = "#{spec} from #{params['from']}" if params.has_key?('from')
 -%>
 
 # <%= assoc %>
+<% sainfos.each do |spec| -%>
 sainfo <%= spec %> {
 	encryption_algorithm <%= Array(params['encryption_algorithm']).join(', ') %>;
 	authentication_algorithm <%= Array(params['authentication_algorithm']).join(', ') %>;
 	compression_algorithm <%= params['compression_algorithm'] %>;
+<%- unless params['lifetime'].nil? -%>
+	lifetime <%= params['lifetime'] %>
+<% end -%>
 }
-<%- end -%>
+<% end -%>
+<% end -%>

--- a/templates/racoon.conf.erb
+++ b/templates/racoon.conf.erb
@@ -37,17 +37,17 @@ sainfo_defaults = {
 log <%= @log_level %>;
 path pre_shared_key "/etc/racoon/psk.txt";
 path certificate "/etc/racoon/certs";
-<%- @remotes.each do |remote, raw_params|
-      params = remote_defaults.merge(raw_params) -%>
+<% @remotes.each do |remote, given_params|
+    params = remote_defaults.merge(given_params) -%>
 
 # <%= remote %>
 remote <%= params['address'] %> {
 	exchange_mode <%= params['mode'] %>;
 
 	my_identifier <%= params['my_identifier']['type'] %> <%= params['my_identifier']['value'] %>;
-        <%- unless params['peers_identifier'].nil? -%>
+    <%- unless params['peers_identifier'].nil? -%>
 	peers_identifier <%= params['peers_identifier']['type'] %> <%= params['peers_identifier']['value'] %>;
-        <%- end -%>
+    <%- end -%>
 
 	generate_policy <%= params['generate_policy'] ? 'on' : 'off' %>;
 	passive <%= params['passive'] ? 'on' : 'off' %>;
@@ -56,9 +56,9 @@ remote <%= params['address'] %> {
 	proposal_check <%= params['proposal_check'] %>;
 
 	dpd_delay <%= params['dpd_delay'] %>;
-        <%- unless params['lifetime'].nil? -%>
+    <%- unless params['lifetime'].nil? -%>
 	lifetime <%= params['lifetime'] %>;
-        <%- end -%>
+    <%- end -%>
 	proposal {
 		encryption_algorithm <%= params['proposal']['encryption_algorithm'] %>;
 		hash_algorithm <%= params['proposal']['hash_algorithm'] %>;
@@ -66,17 +66,17 @@ remote <%= params['address'] %> {
 		dh_group <%= params['proposal']['dh_group'] %>;
 	}
 }
-    <%- params['associations'].each do |assoc, raw_params|
-            params = sainfo_defaults.merge(raw_params)
-            lproto = params['local_proto'] || 'any'
-            rproto = params['remote_proto'] || 'any'
-            case params['type']
+    <%- params['associations'].each do |assoc, given_params|
+            assoc_params = sainfo_defaults.merge(given_params)
+            lproto = assoc_params['local_proto'] || 'any'
+            rproto = assoc_params['remote_proto'] || 'any'
+            case assoc_params['type']
                 when 'anonymous'
                     sainfos = ['anonymous']
                 when 'identifiers'
                     sainfos = []
-                    Array(params['local_net']).each do |lnet|
-                        Array(params['remote_net']).each do |rnet|
+                    Array(assoc_params['local_net']).each do |lnet|
+                        Array(assoc_params['remote_net']).each do |rnet|
                             spec = "address #{lnet} #{lproto} address #{rnet} #{rproto}"
                             spec = "#{spec} from #{params['from']}" if params.has_key?('from')
                             sainfos += [spec]
@@ -87,12 +87,12 @@ remote <%= params['address'] %> {
     -%>
 # <%= assoc %>
 sainfo <%= spec %> {
-	encryption_algorithm <%= Array(params['encryption_algorithm']).join(', ') %>;
-	authentication_algorithm <%= Array(params['authentication_algorithm']).join(', ') %>;
-	compression_algorithm <%= params['compression_algorithm'] %>;
-        <%- unless params['lifetime'].nil? -%>
- 	lifetime <%= params['lifetime'] %>;
-        <%- end -%>
+	encryption_algorithm <%= Array(assoc_params['encryption_algorithm']).join(', ') %>;
+	authentication_algorithm <%= Array(assoc_params['authentication_algorithm']).join(', ') %>;
+	compression_algorithm <%= assoc_params['compression_algorithm'] %>;
+            <%- unless assoc_params['lifetime'].nil? -%>
+	lifetime <%= assoc_params['lifetime'] %>;
+            <%- end -%>
 }
 <%-         end
         end

--- a/templates/racoon.conf.erb
+++ b/templates/racoon.conf.erb
@@ -8,7 +8,10 @@ remote_defaults = {
 }
 sainfo_defaults = {
     'type' => 'anonymous',
-    'dh_group' => 'modp1024'
+    'dh_group' => 'modp1024',
+    'encryption_algorithm' => 'aes 256',
+    'authentication_algorithm' => 'hmac_sha1',
+    'compression_algorithm' => 'deflate'
 }
 -%>
 #

--- a/templates/racoon.conf.erb
+++ b/templates/racoon.conf.erb
@@ -1,5 +1,7 @@
 <%-
 remote_defaults = {
+    'mode' => 'main',
+    'my_identifier' => { 'type' => 'address', 'value' => @local_gateway },
     'passive' => false,
     'initial_contact' => true,
     'proposal_check' => 'strict',
@@ -50,7 +52,7 @@ remote <%= params['address'] %> {
 	generate_policy <%= params['generate_policy'] ? 'on' : 'off' %>;
 	passive <%= params['passive'] ? 'on' : 'off' %>;
 	initial_contact <%= params['initial_contact'] ? 'on' : 'off' %>;
-	nat_traversal <%= params['nat_traversal'] %>;
+	nat_traversal <%= params['nat_traversal'] ? 'on' : 'off' %>;
 	proposal_check <%= params['proposal_check'] %>;
 
 	dpd_delay <%= params['dpd_delay'] %>;
@@ -89,7 +91,7 @@ sainfo <%= spec %> {
 	authentication_algorithm <%= Array(params['authentication_algorithm']).join(', ') %>;
 	compression_algorithm <%= params['compression_algorithm'] %>;
         <%- unless params['lifetime'].nil? -%>
- 	lifetime <%= params['lifetime'] %>
+ 	lifetime <%= params['lifetime'] %>;
         <%- end -%>
 }
 <%-         end

--- a/templates/racoon.conf.erb
+++ b/templates/racoon.conf.erb
@@ -3,7 +3,8 @@ remote_defaults = {
     'passive' => false,
     'initial_contact' => true,
     'proposal_check' => 'strict',
-    'dpd_delay' => 20
+    'dpd_delay' => 20,
+    'associations' => []
 }
 sainfo_defaults = {
     'type' => 'anonymous',
@@ -39,9 +40,9 @@ remote <%= params['address'] %> {
 	exchange_mode <%= params['mode'] %>;
 
 	my_identifier <%= params['my_identifier']['type'] %> <%= params['my_identifier']['value'] %>;
-<%- unless params['peers_identifier'].nil? -%>
+        <%- unless params['peers_identifier'].nil? -%>
 	peers_identifier <%= params['peers_identifier']['type'] %> <%= params['peers_identifier']['value'] %>;
-<%- end -%>
+        <%- end -%>
 
 	generate_policy <%= params['generate_policy'] ? 'on' : 'off' %>;
 	passive <%= params['passive'] ? 'on' : 'off' %>;
@@ -50,9 +51,9 @@ remote <%= params['address'] %> {
 	proposal_check <%= params['proposal_check'] %>;
 
 	dpd_delay <%= params['dpd_delay'] %>;
-<%- unless params['lifetime'].nil? -%>
-	lifetime <%= params['lifetime'] %>
-<% end -%>
+        <%- unless params['lifetime'].nil? -%>
+	lifetime <%= params['lifetime'] %>;
+        <%- end -%>
 	proposal {
 		encryption_algorithm <%= params['proposal']['encryption_algorithm'] %>;
 		hash_algorithm <%= params['proposal']['hash_algorithm'] %>;
@@ -60,34 +61,35 @@ remote <%= params['address'] %> {
 		dh_group <%= params['proposal']['dh_group'] %>;
 	}
 }
-<%- end -%>
-<%- @associations.each do |assoc, raw_params|
-      params = sainfo_defaults.merge(raw_params)
-      lproto = params['local_proto'] || 'any'
-      rproto = params['remote_proto'] || 'any'
-      case params['type']
-          when 'anonymous'
-              sainfos = ['anonymous']
-          when 'identifiers'
-              sainfos = []
-              Array(params['local_net']).each do |lnet|
-                  Array(params['remote_net']).each do |rnet|
-                      sainfos += ["address #{lnet} #{lproto} address #{rnet} #{rproto}"]
-                  end
-              end
-      end
-      spec = "#{spec} from #{params['from']}" if params.has_key?('from')
--%>
-
+    <%- params['associations'].each do |assoc, raw_params|
+            params = sainfo_defaults.merge(raw_params)
+            lproto = params['local_proto'] || 'any'
+            rproto = params['remote_proto'] || 'any'
+            case params['type']
+                when 'anonymous'
+                    sainfos = ['anonymous']
+                when 'identifiers'
+                    sainfos = []
+                    Array(params['local_net']).each do |lnet|
+                        Array(params['remote_net']).each do |rnet|
+                            spec = "address #{lnet} #{lproto} address #{rnet} #{rproto}"
+                            spec = "#{spec} from #{params['from']}" if params.has_key?('from')
+                            sainfos += [spec]
+                        end
+                    end
+            end
+            sainfos.each do |spec|
+    -%>
 # <%= assoc %>
-<% sainfos.each do |spec| -%>
 sainfo <%= spec %> {
 	encryption_algorithm <%= Array(params['encryption_algorithm']).join(', ') %>;
 	authentication_algorithm <%= Array(params['authentication_algorithm']).join(', ') %>;
 	compression_algorithm <%= params['compression_algorithm'] %>;
-<%- unless params['lifetime'].nil? -%>
-	lifetime <%= params['lifetime'] %>
-<% end -%>
+        <%- unless params['lifetime'].nil? -%>
+ 	lifetime <%= params['lifetime'] %>
+        <%- end -%>
 }
-<% end -%>
-<% end -%>
+<%-         end
+        end
+   end
+-%>


### PR DESCRIPTION
This patch set fixes some bugs, and makes more aspects configurable.  Main feature is that you can have several local and remote networks, and sainfo for each combination will be created.
It should be backwards compatible, with one exception: association data has been moved into params for each remote to make the data structure in hiera-data easier to read.
Let me know if you want to break this into smaller pieces.
